### PR TITLE
feat: コメントのリアルタイム同期（onSnapshot）を導入

### DIFF
--- a/src/lib/commentRepository.ts
+++ b/src/lib/commentRepository.ts
@@ -9,6 +9,7 @@ import {
   query,
   orderBy,
   where,
+  onSnapshot,
 } from 'firebase/firestore';
 
 const COMMENT_COLLECTION = 'comments';
@@ -27,4 +28,17 @@ export async function addComment(comment: Omit<Comment, 'id'>): Promise<string> 
 export async function deleteComment(id: string) {
   const docRef = doc(db, COMMENT_COLLECTION, id);
   await deleteDoc(docRef);
+}
+
+// コメントのリアルタイム購読
+export function subscribeComments(assetId: string, callback: (comments: Comment[]) => void) {
+  const q = query(
+    collection(db, COMMENT_COLLECTION),
+    where('assetId', '==', assetId),
+    orderBy('createdAt', 'asc')
+  );
+  return onSnapshot(q, (snapshot) => {
+    const comments = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as Comment));
+    callback(comments);
+  });
 } 

--- a/src/pages/assets/[id].tsx
+++ b/src/pages/assets/[id].tsx
@@ -5,7 +5,7 @@ import { fetchAssetById, deleteAsset, deleteAssetFile, updateAsset, uploadAssetF
 import { Asset } from "@/types/asset";
 import { createVersion, fetchVersionById } from "@/lib/versionRepository";
 import { Version } from "@/types/version";
-import { fetchComments, addComment, deleteComment, subscribeComments } from "@/lib/commentRepository";
+import { addComment, deleteComment, subscribeComments } from "@/lib/commentRepository";
 import { Comment } from "@/types/comment";
 import Image from "next/image";
 import { useAuth } from "@/contexts/AuthContext";

--- a/src/pages/assets/[id].tsx
+++ b/src/pages/assets/[id].tsx
@@ -5,7 +5,7 @@ import { fetchAssetById, deleteAsset, deleteAssetFile, updateAsset, uploadAssetF
 import { Asset } from "@/types/asset";
 import { createVersion, fetchVersionById } from "@/lib/versionRepository";
 import { Version } from "@/types/version";
-import { fetchComments, addComment, deleteComment } from "@/lib/commentRepository";
+import { fetchComments, addComment, deleteComment, subscribeComments } from "@/lib/commentRepository";
 import { Comment } from "@/types/comment";
 import Image from "next/image";
 import { useAuth } from "@/contexts/AuthContext";
@@ -37,7 +37,9 @@ export default function AssetDetail() {
           fetchVersionById(data.latestVersionId).then(setLatestVersion);
         }
       });
-      fetchComments(id).then(setComments);
+      // コメントのリアルタイム購読
+      const unsubscribe = subscribeComments(id, setComments);
+      return () => unsubscribe();
     }
   }, [id]);
 
@@ -150,18 +152,13 @@ export default function AssetDetail() {
       createdAt: now,
     });
     setCommentInput("");
-    const updated = await fetchComments(id as string);
-    setComments(updated);
     setCommentLoading(false);
   };
 
   const handleDeleteComment = async (commentId: string) => {
     if (!window.confirm("このコメントを削除しますか？")) return;
     await deleteComment(commentId);
-    if (id) {
-      const updated = await fetchComments(id as string);
-      setComments(updated);
-    }
+    // コメントはonSnapshotで自動更新されるので再取得不要
   };
 
   return (


### PR DESCRIPTION
アセット詳細画面のコメント機能にFirestoreのonSnapshotを導入し、コメントの追加・削除がリアルタイムで反映されるようにしました。\n\n- commentRepository.ts: subscribeComments関数を追加\n- [id].tsx: コメント取得・更新処理をonSnapshot購読に変更\n- 未使用のfetchCommentsインポートを削除（Copilotレビュー指摘対応）\n\nご確認よろしくお願いします。